### PR TITLE
Updated connected level retrieval

### DIFF
--- a/.github/workflows/lvlspy_test.py
+++ b/.github/workflows/lvlspy_test.py
@@ -63,10 +63,10 @@ def test_transitions():
     coll = get_collection()
     s = coll.get()["al26"]
     levels = s.get_levels()
-    upwards = s.get_upward_transitions_from_level(levels[0])
-    assert len(upwards) > 0
-    downwards = s.get_downward_transitions_from_level(levels[len(levels) - 1])
-    assert len(downwards) > 0
+    assert len(s.get_lower_linked_levels(levels[0])) == 0
+    assert len(s.get_upper_linked_levels(levels[0])) > 0
+    assert len(s.get_lower_linked_levels(levels[len(levels) - 1])) > 0
+    assert len(s.get_upper_linked_levels(levels[len(levels) - 1])) == 0
     transitions = s.get_transitions()
     number_transitions = len(transitions)
     transition = transitions[0]

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -4,11 +4,14 @@ Changelog
 All notable changes to this project will be documented in this file.  This
 project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 
-Version 2.0.1
+Version 3.0.0
 -------------
 
 Fix:
 
+  * Misleading methods to retrieve upward and downward transitions have been
+    replaced with methods to retrieve levels linked by transitions to a
+    given level.  This is a backwards-incompatible change.
   * If a level or transition already exists in the respective collection,
     the API now updates the level or transition instead of adding a new version.
   * An overflow on the Boltzmann factor for zero temperature has been fixed.

--- a/lvlspy/__about__.py
+++ b/lvlspy/__about__.py
@@ -10,6 +10,6 @@ __all__ = [
 
 __title__ = "lvlspy"
 __summary__ = "Python project to work with quantum level system data"
-__version__ = "2.0.1"
+__version__ = "3.0.0"
 __author__ = "Clemson University"
 __copyright__ = "Clemson University, 2022-2023"

--- a/lvlspy/spcoll.py
+++ b/lvlspy/spcoll.py
@@ -118,17 +118,19 @@ class SpColl(lp.Properties):
 
     def _add_transitions_to_xml(self, xml_level, species, level, units):
 
-        transitions = species.get_downward_transitions_from_level(level)
+        lower_levels = species.get_lower_linked_levels(level)
 
-        if len(transitions) == 0:
+        if len(lower_levels) == 0:
             return
 
         xml_transitions = etree.SubElement(xml_level, "transitions")
 
-        for transition in transitions:
+        for lower_level in lower_levels:
+            transition = species.get_level_to_level_transition(
+                level, lower_level
+            )
             xml_trans = etree.SubElement(xml_transitions, "transition")
             self._add_optional_properties(xml_trans, transition)
-            lower_level = transition.get_lower_level()
             if units != "keV":
                 xml_to_energy = etree.SubElement(
                     xml_trans, "to_energy", units=units

--- a/lvlspy/species.py
+++ b/lvlspy/species.py
@@ -108,43 +108,45 @@ class Species(lp.Properties):
 
         self.transitions.remove(transition)
 
-    def get_upward_transitions_from_level(self, level):
-        """Method to retrieve the upward transitions (those requiring
-        absorption of energy) from a level in a species.
+    def get_lower_linked_levels(self, level):
+        """Method to retrieve the lower-energy levels linked to the input level
+        by transitions in the species.
 
         Args:
-            ``level`` (:obj:`lvlspy.level.Level`) The level from which
-            the upward transitions originate.
+            ``level`` (:obj:`lvlspy.level.Level`) The level for which
+            the linked levels are sought.
 
         Return:
-            :obj:`list`: A list of the upward transitions from the level.
-
-        """
-
-        result = []
-        for transition in self.get_transitions():
-            if transition.get_lower_level() == level:
-                result.append(transition)
-
-        return result
-
-    def get_downward_transitions_from_level(self, level):
-        """Method to retrieve the downward transitions (those releasing
-        energy) from a level in a species.
-
-        Args:
-            ``level`` (:obj:`lvlspy.level.Level`) The level from which
-            the downward transitions originate.
-
-        Return:
-            :obj:`list`: A list of the downward transitions from the level.
+            :obj:`list`: A list of the lower-energy levels linked to the
+            input level by transitions.
 
         """
 
         result = []
         for transition in self.get_transitions():
             if transition.get_upper_level() == level:
-                result.append(transition)
+                result.append(transition.get_lower_level())
+
+        return result
+
+    def get_upper_linked_levels(self, level):
+        """Method to retrieve the higher-energy levels linked to the input level
+        by transitions in the species.
+
+        Args:
+            ``level`` (:obj:`lvlspy.level.Level`) The level for which
+            the linked levels are sought.
+
+        Return:
+            :obj:`list`: A list of the higher-energy levels linked to the
+            input level by transitions.
+
+        """
+
+        result = []
+        for transition in self.get_transitions():
+            if transition.get_lower_level() == level:
+                result.append(transition.get_upper_level())
 
         return result
 


### PR DESCRIPTION
Replace methods to retrieve upwards and downwards transitions with methods to retrieve linked levels to given level by transitions.